### PR TITLE
Fix ptcop write functions

### DIFF
--- a/pxtone/pxtnData.cpp
+++ b/pxtone/pxtnData.cpp
@@ -104,6 +104,12 @@ void _int_to_v(uint8_t* bytes5, int* p_byte_num, uint32_t i) {
   bytes5[4] = 0;
   a[4] = 0;
 
+  // OPNA2608 EDIT
+  // need to reverse order on big endian for byte order to match expectation
+  if (_is_big_endian()) {
+    pxtnData::_correct_endian(static_cast<unsigned char*>(a), 4, 1);
+  }
+
   // 1byte(7bit)
   if (i < 0x00000080) {
     *p_byte_num = 1;

--- a/pxtone/pxtnWoice_io.cpp
+++ b/pxtone/pxtnWoice_io.cpp
@@ -144,7 +144,7 @@ bool pxtnWoice::io_matePTN_w( void* desc ) const
 	// if( !_io_write( desc, &ptn,  sizeof(_MATERIALSTRUCT_PTN), 1 ) ) return false;
 	if( !_io_write( desc, &ptn.x3x_unit_no,  sizeof(uint16_t), 1 ) ) return false;
 	if( !_io_write( desc, &ptn.basic_key,  sizeof(uint16_t), 1 ) ) return false;
-	if( !_io_write( desc, &ptn.voice_flags,  sizeof(uint16_t), 1 ) ) return false;
+	if( !_io_write( desc, &ptn.voice_flags,  sizeof(uint32_t), 1 ) ) return false;
 	if( !_io_write( desc, &ptn.tuning,  sizeof(float), 1 ) ) return false;
 	if( !_io_write( desc, &ptn.rrr,  sizeof(int32_t), 1 ) ) return false;
 
@@ -232,22 +232,14 @@ bool pxtnWoice::io_matePTV_w( void* desc ) const
 
 	// pre write
 
-	// ewan edit; init. each struct member individually (for endianness) and put writing code into its own routine
-	auto write = [=] () -> bool {
-		if( !_io_write( desc, &size, sizeof(int32_t),             1 ) ) return false;
-		//if( !_io_write( desc, &ptv,  sizeof(_MATERIALSTRUCT_PTV), 1 ) ) return false;
-
-		if( !_io_write( desc, &ptv.x3x_unit_no,  sizeof(uint16_t), 1 ) ) return false;
-		if( !_io_write( desc, &ptv.rrr,  sizeof(uint16_t), 1 ) ) return false;
-		if( !_io_write( desc, &ptv.x3x_tuning,  sizeof(float), 1 ) ) return false;
-		if( !_io_write( desc, &ptv.size,  sizeof(int32_t), 1 ) ) return false;
-
-		return true;
-	};
-
-	//if( !_io_write( desc, &size, sizeof(int32_t),             1 ) ) return false;
+	// ewan edit; init. each struct member individually (for endianness)
+	if( !_io_write( desc, &size, sizeof(int32_t),             1 ) ) return false;
 	//if( !_io_write( desc, &ptv,  sizeof(_MATERIALSTRUCT_PTV), 1 ) ) return false;
-	if(!write()) return false;
+
+	if( !_io_write( desc, &ptv.x3x_unit_no,  sizeof(uint16_t), 1 ) ) return false;
+	if( !_io_write( desc, &ptv.rrr,  sizeof(uint16_t), 1 ) ) return false;
+	if( !_io_write( desc, &ptv.x3x_tuning,  sizeof(float), 1 ) ) return false;
+	if( !_io_write( desc, &ptv.size,  sizeof(int32_t), 1 ) ) return false;
 
 	if( !PTV_Write( desc, &ptv.size ) ) return false;
 
@@ -255,9 +247,14 @@ bool pxtnWoice::io_matePTV_w( void* desc ) const
 
 	size = ptv.size +  sizeof(_MATERIALSTRUCT_PTV);
 
-	//if( !_io_write( desc, &size, sizeof(int32_t),             1 ) ) return false;
+	// ewan edit; init. each struct member individually (for endianness)
+	if( !_io_write( desc, &size, sizeof(int32_t),             1 ) ) return false;
 	//if( !_io_write( desc, &ptv,  sizeof(_MATERIALSTRUCT_PTV), 1 ) ) return false;
-	if(!write()) return false;
+
+	if( !_io_write( desc, &ptv.x3x_unit_no,  sizeof(uint16_t), 1 ) ) return false;
+	if( !_io_write( desc, &ptv.rrr,  sizeof(uint16_t), 1 ) ) return false;
+	if( !_io_write( desc, &ptv.x3x_tuning,  sizeof(float), 1 ) ) return false;
+	if( !_io_write( desc, &ptv.size,  sizeof(int32_t), 1 ) ) return false;
 
 	if( !_io_seek ( desc, SEEK_CUR, ptv.size ) ) return false;
 


### PR DESCRIPTION
Wrong write size of one struct member, and the lambda expression broke the size variables.