### PR TITLE
Fix CI deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Setup Toolchain [Windows MSVC]
         if: ${{ matrix.config.compiler == 'msvc' }}
-        uses: seanmiddleditch/gha-setup-vsdevenv@v4
+        uses: vadz/gha-setup-vsdevenv@avoid-deprecation-warnings # https://github.com/seanmiddleditch/gha-setup-vsdevenv/pull/15
 
       - name: Setup Toolchain [Windows MinGW]
         if: ${{ matrix.config.compiler == 'mingw' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
           echo "Amount of cores we can build with: ${amount}"
 
-          echo "::set-output name=amount::${amount}"
+          echo "amount=${amount}" >> $GITHUB_OUTPUT
 
       - name: Set artifact identifier
         id: artifact-id
@@ -56,7 +56,7 @@ jobs:
 
           echo "Artifact identifier: ${artifact_id}"
 
-          echo "::set-output name=id::${artifact_id}"
+          echo "id=${artifact_id}" >> $GITHUB_OUTPUT
 
       - name: Setup Toolchain [Windows MSVC]
         if: ${{ matrix.config.compiler == 'msvc' }}


### PR DESCRIPTION
![Bildschirmfoto von 2022-11-08 15-52-54](https://user-images.githubusercontent.com/23431373/200596976-d043b70c-fdbd-44ac-b40d-042a03a71849.png)

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
\+ switching to a fork of https://github.com/seanmiddleditch/gha-setup-vsdevenv while the corresponding upstream PR is unmerged.